### PR TITLE
Updates example queries

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -64,11 +64,11 @@ const TEMPLATE_QUERIES = {
 
 const EXAMPLE_QUERIES = {
     'example1' : {
-        TITLE: 'DBpedia: Born in Calcutta ...',
+        TITLE: 'DBpedia: Born in Kolkata ...',
         VF_PREDICATE: 'birthPlace',
         VF_PREDICATE_HIDDEN: 'http://dbpedia.org/ontology/birthPlace',
-        VF_OBJECT: 'Calcutta',
-        VF_OBJECT_HIDDEN: 'http://dbpedia.org/resource/Calcutta',
+        VF_OBJECT: 'Kolkata',
+        VF_OBJECT_HIDDEN: 'http://dbpedia.org/resource/Kolkata',
         VRF_PREDICATE: 'birthDate',
         VRF_PREDICATE_HIDDEN: 'http://dbpedia.org/ontology/birthDate',
         VRF_MIN: '1900-01-01',
@@ -88,8 +88,8 @@ const EXAMPLE_QUERIES = {
     # Get all entities from https://dbpedia.org/sparql ... 
     SELECT ?subject ?showAttributeVal WHERE { 
     
-    # ... with Calcutta as value for birth place ... 
-    ?subject <http://dbpedia.org/ontology/birthPlace> <http://dbpedia.org/resource/Calcutta> . 
+    # ... with Kolkata as value for birth place ... 
+    ?subject <http://dbpedia.org/ontology/birthPlace> <http://dbpedia.org/resource/Kolkata> . 
     
     # ... with birth date between 1900-01-01 and 1945-01-01 ... 
     ?subject <http://dbpedia.org/ontology/birthDate> ?value . 
@@ -106,7 +106,7 @@ const EXAMPLE_QUERIES = {
     
     LIMIT 20 # Return max 20 results
         `,
-        DESC: 'People born in Calcutta between 1900-01-01 and 1945-01-01 whose names start with S and their spouses'
+        DESC: 'People born in Kolkata between 1900-01-01 and 1945-01-01 whose names start with S and their spouses'
     },
 
     'example2' : {
@@ -120,9 +120,9 @@ const EXAMPLE_QUERIES = {
         VRF_MIN: '100',
         VRF_MAX: '400',
         DTYPE: 'xsd:integer',
-        SMF_PREDICATE: 'has abstract',
-        SMF_PREDICATE_HIDDEN: 'http://dbpedia.org/ontology/abstract',
-        SMF_REGEX: 'adapt',
+        SMF_PREDICATE: 'description',
+        SMF_PREDICATE_HIDDEN: 'http://dbpedia.org/ontology/description',
+        SMF_REGEX: 'child',
         DP_PREDICATE: 'publisher',
         DP_PREDICATE_HIDDEN: 'http://dbpedia.org/property/publisher',
         LIMIT: '100',
@@ -141,9 +141,9 @@ const EXAMPLE_QUERIES = {
     ?subject <http://dbpedia.org/property/pages> ?value . 
     FILTER(?value >= "100"^^xsd:integer && ?value <= "400"^^xsd:integer) 
     
-    # ... with has abstract matching the regular expression adapt ... 
-    ?subject <http://dbpedia.org/ontology/abstract> ?regexValue . 
-    FILTER(regex(?regexValue, "adapt", "i")) 
+    # ... with description matching the regular expression child ... 
+    ?subject <http://dbpedia.org/ontology/description> ?regexValue . 
+    FILTER(regex(?regexValue, "child", "i")) 
     
     # ... display the values for these entities ... 
     ?subject <http://dbpedia.org/property/publisher> ?showAttributeVal . 
@@ -152,7 +152,7 @@ const EXAMPLE_QUERIES = {
     
     LIMIT 100 # Return max 100 results
         `,
-        DESC: 'Books by Roald Dahl that are between 100 and 400 pages long that have been adapted as a film or theatre production (the description of the book should contain the word `adapt` in it somewhere indicating a film or theatre adaptation), display also the publishers of these books.'
+        DESC: 'Books by Roald Dahl that are between 100 and 400 pages long that have the word `child` in it, potentially indicating a children`s book.'
     },
 
     'example3' : {
@@ -166,9 +166,9 @@ const EXAMPLE_QUERIES = {
         VRF_MIN: '0',
         VRF_MAX: '6000',
         DTYPE: 'xsd:double',
-        SMF_PREDICATE: 'has abstract',
-        SMF_PREDICATE_HIDDEN: 'http://dbpedia.org/ontology/abstract',
-        SMF_REGEX: 'Oscar',
+        SMF_PREDICATE: 'description',
+        SMF_PREDICATE_HIDDEN: 'http://dbpedia.org/ontology/description',
+        SMF_REGEX: '1983',
         DP_PREDICATE: 'film director',
         DP_PREDICATE_HIDDEN: 'http://dbpedia.org/ontology/director',
         LIMIT: '100',
@@ -187,9 +187,9 @@ const EXAMPLE_QUERIES = {
     ?subject <http://dbpedia.org/ontology/runtime> ?value .
     FILTER(?value >= "0"^^xsd:double && ?value <= "6000"^^xsd:double)
     
-    # ... with has abstract matching the regular expression Oscar ... 
-    ?subject <http://dbpedia.org/ontology/abstract> ?regexValue .
-    FILTER(regex(?regexValue, "Oscar", "i"))
+    # ... with description matching the regular expression 1983 ... 
+    ?subject <http://dbpedia.org/ontology/description> ?regexValue .
+    FILTER(regex(?regexValue, "1983", "i"))
     
     # ... display the film director values for these entities ...
     ?subject <http://dbpedia.org/ontology/director> ?showAttributeVal .
@@ -198,7 +198,7 @@ const EXAMPLE_QUERIES = {
 
     LIMIT 100 # Return max 100 results
         `,
-        DESC: 'Short movies (less than 100 minutes long) starring Tom Cruise that have been associated with Oscars, also display their directors'
+        DESC: 'Short movies (less than 100 minutes long) starring Tom Cruise that have `1983` in the description of the movie (potentially made in that year), also display their directors.'
     }
 }
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -729,6 +729,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -848,13 +863,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -1002,6 +1019,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -2011,7 +2043,7 @@
         "combined-stream": "~1.0.6",
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~4.0.0",
+        "form-data": "^4.0.4",
         "http-signature": "~1.4.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -2525,6 +2557,18 @@
         "es-errors": "^1.3.0"
       }
     },
+    "es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -2612,13 +2656,15 @@
       "dev": true
     },
     "form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       }
     },
@@ -2727,6 +2773,15 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true
+    },
+    "has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.3"
+      }
     },
     "hasown": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
   },
   "dependencies": {
     "jquery": "^3.7.1"
+  },
+  "overrides": {
+   "form-data": "^4.0.4"
   }
 }


### PR DESCRIPTION
- Previous example queries stopped returning results because DBpedia updated to remove dbo:abstract property and changed dbr:Calcutta to dbr:Kolkata. This PR updates the example queries to return some results again.
- Fixes a security vulnerability with form-data package (dependency of Cypress) by bumping up the version to one that patches the vulnerability.